### PR TITLE
Rename list_ids to list_names

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,15 +13,16 @@
   },
   "contributors": [
     "Chris Grayson <chris@activeprospect.com>",
-    "Taylor Brooks <taylor@activeprospect.com>"
+    "Taylor Brooks <taylor@activeprospect.com>",
+    "Alex Wolfe <alex@activeprospect.com>"
   ],
   "license": "CC-BY-NC-ND-4.0",
   "engines": {
     "node": ">0.10.26"
   },
   "dependencies": {
-    "timekeeper": "0.0.4",
-    "mime-content": ">=0.0.6"
+    "csvrow": "^0.1.0",
+    "lodash": "^3.10.1"
   },
   "devDependencies": {
     "coffee-script": ">= 1.7.0",

--- a/spec/add_item_spec.coffee
+++ b/spec/add_item_spec.coffee
@@ -10,13 +10,13 @@ describe 'Add List Item', ->
       request = integration.request(activeprospect: {api_key: '1234'}, list_id: 'things', values: 'boilermakers@example.com, taylor@activeprospect.com')
 
     it 'should have url', ->
-      assert.equal 'https://app.suppressionlist.com/lists/things/items', request.url
+      assert.equal request.url, 'https://app.suppressionlist.com/lists/things/items'
 
     it 'should be get', ->
-      assert.equal 'POST', request.method
+      assert.equal request.method, 'POST'
 
     it 'should have the correct body', ->
-      assert.equal '{"values":"boilermakers@example.com|taylor@activeprospect.com"}', request.body
+      assert.equal request.body, '{"values":["boilermakers@example.com","taylor@activeprospect.com"]}'
 
   describe 'Response', ->
     it 'should parse JSON body', ->
@@ -28,9 +28,8 @@ describe 'Add List Item', ->
           'Content-Type': 'application/json; charset=utf-8'
         body: """
               {
-              "outcome": "success",
-              "accepted": 2,
-              "rejected": 0
+                "accepted": 2,
+                "rejected": 0
               }
               """
       expected =
@@ -40,7 +39,7 @@ describe 'Add List Item', ->
           accepted: 2
           rejected: 0
       response = integration.response(vars, req, res)
-      assert.deepEqual expected, response
+      assert.deepEqual response, expected
 
     it 'should return error outcome on non-200 response status', ->
       vars = {}
@@ -51,16 +50,15 @@ describe 'Add List Item', ->
           'Content-Type': 'application/json'
         body: """
               {
-              "outcome":"error",
-              "reason":"SuppressionList error (400)"
+                "error":"Something went wrong"
               }
               """
       expected =
         add_item:
           outcome: 'error'
-          reason: 'SuppressionList error (400)'
+          reason: 'Something went wrong'
       response = integration.response(vars, req, res)
-      assert.deepEqual expected, response
+      assert.deepEqual response, expected
 
     it 'should return error outcome on 500/HTML response', ->
       vars = {}
@@ -99,9 +97,9 @@ describe 'Add List Item', ->
       expected =
         add_item:
           outcome: 'error'
-          reason: 'SuppressionList error (500) Possibly incorrect list_id'
+          reason: 'Unsupported response'
       response = integration.response(vars, req, res)
-      assert.deepEqual expected, response
+      assert.deepEqual response, expected
 
   describe 'Validate', ->
     it 'should function properly', ->

--- a/spec/delete_item_spec.coffee
+++ b/spec/delete_item_spec.coffee
@@ -10,13 +10,13 @@ describe 'Delete List Item', ->
       request = integration.request(activeprospect: {api_key: '1234'}, list_id: 'things', values: 'taylor@activeprospect.com')
 
     it 'should have url', ->
-      assert.equal 'https://app.suppressionlist.com/lists/things/items', request.url
+      assert.equal request.url, 'https://app.suppressionlist.com/lists/things/items'
 
     it 'should be delete', ->
-      assert.equal 'DELETE', request.method
+      assert.equal  request.method, 'DELETE'
 
     it 'should have body', ->
-      assert.equal '{"values":"taylor@activeprospect.com"}', request.body
+      assert.equal request.body, '{"values":["taylor@activeprospect.com"]}'
 
 
   describe 'Response', ->
@@ -29,9 +29,8 @@ describe 'Delete List Item', ->
           'Content-Type': 'application/json; charset=utf-8'
         body: """
               {
-              "outcome": "success",
-              "deleted": 2,
-              "rejected": 0
+                "deleted": 2,
+                "rejected": 0
               }
               """
       expected =
@@ -52,14 +51,13 @@ describe 'Delete List Item', ->
           'Content-Type': 'application/json'
         body: """
               {
-              "outcome":"error",
-              "reason":"SuppressionList error (400)"
+                "error":"Something went wrong"
               }
               """
       expected =
         delete_item:
           outcome: 'error'
-          reason: 'SuppressionList error (400)'
+          reason: 'Something went wrong'
       response = integration.response(vars, req, res)
       assert.deepEqual expected, response
 
@@ -100,7 +98,7 @@ describe 'Delete List Item', ->
       expected =
         delete_item:
           outcome: 'error'
-          reason: 'SuppressionList error (500) Possibly incorrect list_id'
+          reason: 'Unsupported response'
       response = integration.response(vars, req, res)
       assert.deepEqual expected, response
 

--- a/spec/helper_spec.coffee
+++ b/spec/helper_spec.coffee
@@ -3,27 +3,47 @@ helper = require('../src/helper')
 fields = require('leadconduit-fields')
 
 describe 'Helper', ->
+  
+  describe 'get list URL names', ->
 
-  describe 'Validate', ->
+    for key in ['list_ids', 'list_id', 'list_names', 'list_name']
+      do (key) ->
+        describe "specified with #{key}", ->
+          it 'should handle single value', ->
+            vars = {}
+            vars[key] = 'foo'
+            assert.deepEqual helper.getListUrlNames(vars), 'foo'
 
-    it 'should require list_ids', () ->
-      assert.equal helper.validate({}), 'list_ids must not be blank'
+          it 'should handle comma delimited list', ->
+            vars = {}
+            vars[key] = 'foo,bar,baz'
+            assert.deepEqual helper.getListUrlNames(vars), 'foo|bar|baz'
 
-    it 'should require values', () ->
-      assert.equal helper.validate(list_ids: 'foo'), 'values must not be blank'
+          it 'should ignore comma delimited empty values', ->
+            vars = {}
+            vars[key] = ',,foo,,bar,baz,,'
+            assert.deepEqual helper.getListUrlNames(vars), 'foo|bar|baz'
 
-    it 'should require values', () ->
-      assert.equal helper.validate(list_ids: 'foo', values: ''), 'values must not be blank'
+          it 'should handle array', ->
+            vars = {}
+            vars[key] = ['foo', 'bar', 'baz']
+            assert.deepEqual helper.getListUrlNames(vars), 'foo|bar|baz'
 
-    it 'should require values', () ->
-      assert.equal helper.validate(list_ids: 'foo', values: null), 'values must not be blank'
+          it 'should handle array with empty values', ->
+            vars = {}
+            vars[key] = ['foo', null, 'bar', '', 'baz', '']
+            assert.deepEqual helper.getListUrlNames(vars), 'foo|bar|baz'
 
-    it 'should require values in typed fields', () ->
-      lead = fields.buildLeadVars email: ""  # an empty lead.email (a String) is different than ''
-      assert.equal helper.validate(list_ids: 'foo', values: lead.email), 'values must not be blank'
+          it 'should handle array of comma delimited lists', ->
+            vars = {}
+            vars[key] = ['foo,bar,baz', 'bip,bap']
+            assert.deepEqual helper.getListUrlNames(vars), 'foo|bar|baz|bip|bap'
 
-    it 'should be satisfied with list_ids and values', () ->
-      assert.isUndefined helper.validate(list_ids: 'foo', values: 'bar@baz.com')
+          it 'should slugify', ->
+            vars = {}
+            vars[key] = 'My List,"Bob\'s List, Unplugged",2015-10-12'
+            assert.deepEqual helper.getListUrlNames(vars), 'my_list|bobs_list_unplugged|20151012'
+
 
   describe 'Base URL', ->
 
@@ -41,6 +61,30 @@ describe 'Helper', ->
     it 'should get development url', ->
       process.env.NODE_ENV = 'development'
       assert.equal helper.getBaseUrl(), 'http://suppressionlist.dev'
+
+
+  describe 'Validate', ->
+
+    it 'should require list_ids', () ->
+      assert.equal helper.validate({}), 'a list name is required'
+
+    it 'should require values', ->
+      assert.equal helper.validate(list_ids: 'foo'), 'values must not be blank'
+
+    it 'should require non empty string values', ->
+      assert.equal helper.validate(list_ids: 'foo', values: ''), 'values must not be blank'
+
+    it 'should require non null values', ->
+      assert.equal helper.validate(list_ids: 'foo', values: null), 'values must not be blank'
+
+    it 'should require values in typed fields', () ->
+      lead = fields.buildLeadVars email: ""  # an empty lead.email (a String) is different than ''
+      assert.equal helper.validate(list_ids: 'foo', values: lead.email), 'values must not be blank'
+
+    it 'should be satisfied with list_ids and values', () ->
+      assert.isUndefined helper.validate(list_ids: 'foo', values: 'bar@baz.com')
+
+
 
   describe 'Request Headers', ->
     headers = {}

--- a/spec/query_item_spec.coffee
+++ b/spec/query_item_spec.coffee
@@ -10,10 +10,10 @@ describe 'Query List Item', ->
       request = integration.request(activeprospect: {api_key: '1234'}, list_ids: 'seabass, things, more_things', values: 'boilermakers@example.com')
 
     it 'should have url', ->
-      assert.equal 'https://app.suppressionlist.com/exists/seabass|things|more_things/boilermakers@example.com', request.url
+      assert.equal request.url, 'https://app.suppressionlist.com/exists/seabass|things|more_things/boilermakers@example.com'
 
     it 'should be get', ->
-      assert.equal 'GET', request.method
+      assert.equal request.method, 'GET'
 
 
   describe 'Response', ->
@@ -26,10 +26,10 @@ describe 'Query List Item', ->
           'Content-Type': 'application/json'
         body: """
               {
-              "specified_lists": ["list_1", "list_2", "list_3"],
-              "key": "taylor@activeprospect.com",
-              "found": true,
-              "exists_in_lists": ["list_2", "list_3"]
+                "specified_lists": ["list_1", "list_2", "list_3"],
+                "key": "taylor@activeprospect.com",
+                "found": true,
+                "exists_in_lists": ["list_2", "list_3"]
               }
               """
       expected =
@@ -41,7 +41,7 @@ describe 'Query List Item', ->
           found: true
           found_in: ["list_2", "list_3"]
       response = integration.response(vars, req, res)
-      assert.deepEqual expected, response
+      assert.deepEqual response, expected
 
     it 'should return error outcome on non-200 response status', ->
       vars = {}
@@ -52,17 +52,15 @@ describe 'Query List Item', ->
           'Content-Type': 'application/json'
         body: """
               {
-              "outcome":"error",
-              "reason":"SuppressionList error (400)",
-              "error": "No such account."
+                "error":"No such account"
               }
               """
       expected =
         query_item:
           outcome: 'error'
-          reason: 'SuppressionList error (400) No such account.'
+          reason: 'No such account'
       response = integration.response(vars, req, res)
-      assert.deepEqual expected, response
+      assert.deepEqual response, expected
 
     it 'should return success outcome on not-found/404 response status', ->
       res =
@@ -71,10 +69,9 @@ describe 'Query List Item', ->
           'Content-Type': "application/json"
         body: """
               {
-              "specified_lists": ["list_1"],
-              "key": "taylor@swift.com",
-              "found": false,
-              "reason": null
+                "specified_lists": ["list_1"],
+                "key": "taylor@swift.com",
+                "found": false
               }
               """
       expected =

--- a/src/add_item.coffee
+++ b/src/add_item.coffee
@@ -1,10 +1,11 @@
-mimecontent = require('mime-content')
 helper = require('./helper')
 
 request = (vars) ->
-  values = helper.getValues vars
+  values = helper.getValues(vars)
+  listNames = helper.getListUrlNames(vars)
+  baseUrl = helper.getBaseUrl()
 
-  url: "#{helper.getBaseUrl()}/lists/#{vars.list_id}/items"
+  url: "#{baseUrl}/lists/#{listNames}/items"
   method: 'POST'
   headers: helper.getRequestHeaders(vars.activeprospect.api_key)
   body:
@@ -12,8 +13,8 @@ request = (vars) ->
 
 request.variables = ->
   [
-    { name: 'list_id', description: 'SuppressionList List Id', required: true, type: 'string' }
-    { name: 'values', description: 'Item(s) to be added to SuppressionList (comma separated)', required: true, type: 'string' }
+    { name: 'list_name', description: 'SuppressionList List URL Name', required: true, type: 'string' }
+    { name: 'values', description: 'Phone, email or other values to be added to the list (comma separated)', required: true, type: 'string' }
   ]
 
 
@@ -22,10 +23,10 @@ response = (vars, req, res) ->
 
 response.variables = ->
   [
-    { name: 'add_item.outcome', type: 'string', description: 'Was SuppressionList response data appended?' },
-    { name: 'add_item.reason', type: 'string', description: 'Error reason' },
-    { name: 'add_item.accepted', type: 'number', description: 'the number of items added to the list'},
-    { name: 'add_item.rejected', type: 'number', description: 'the number of items not added to the list'}
+    { name: 'add_item.outcome', type: 'string', description: 'Was SuppressionList response data appended?' }
+    { name: 'add_item.reason', type: 'string', description: 'Error reason' }
+    { name: 'add_item.accepted', type: 'number', description: 'the number of items added to the list' }
+    { name: 'add_item.rejected', type: 'number', description: 'the number of items not added to the list' }
   ]
 
 

--- a/src/delete_item.coffee
+++ b/src/delete_item.coffee
@@ -1,18 +1,19 @@
-mimecontent = require('mime-content')
 helper = require('./helper')
 
 request = (vars) ->
-  values = helper.getValues vars
+  values = helper.getValues(vars)
+  listNames = helper.getListUrlNames(vars)
+  baseUrl = helper.getBaseUrl()
 
-  url: "#{helper.getBaseUrl()}/lists/#{vars.list_id}/items"
+  url: "#{baseUrl}/lists/#{listNames}/items"
   method: 'DELETE'
   headers: helper.getRequestHeaders(vars.activeprospect.api_key)
   body: JSON.stringify(values: values)
 
 request.variables = ->
   [
-    { name: 'list_id', description: 'SuppressionList List Id', required: true, type: 'string' }
-    { name: 'values', description: 'Item(s) to be removed from SuppressionList (comma separated)', required: true, type: 'string' }
+    { name: 'list_name',  description: 'SuppressionList List URL Name', required: true, type: 'string' }
+    { name: 'values', description: 'Phone, email or other values to be removed from the specified lists (comma separated)',   required: true, type: 'string' }
   ]
 
 
@@ -21,10 +22,10 @@ response = (vars, req, res) ->
 
 response.variables = ->
   [
-    { name: 'delete_item.outcome', type: 'string', description: 'Was SuppressionList response data appended?' },
-    { name: 'delete_item.reason', type: 'string', description: 'Error reason' },
-    { name: 'delete_item.deleted', type: 'number', description: 'the number of items removed from the list'},
-    { name: 'delete_item.rejected', type: 'number', description: 'the number of items not removed from the list'}
+    { name: 'delete_item.outcome', type: 'string', description: 'Was SuppressionList response data appended?' }
+    { name: 'delete_item.reason', type: 'string', description: 'Error reason' }
+    { name: 'delete_item.deleted', type: 'number', description: 'the number of items removed from the list' }
+    { name: 'delete_item.rejected', type: 'number', description: 'the number of items not removed from the list' }
   ]
 
 

--- a/src/query_item.coffee
+++ b/src/query_item.coffee
@@ -1,25 +1,26 @@
-mimecontent = require('mime-content')
+_ = require('lodash')
 helper = require('./helper')
 
 request = (vars) ->
-  list_ids = helper.getListIds vars
-  values = helper.getValues vars
+  listNames = helper.getListUrlNames(vars)
+  values = helper.getValues(vars).join('|')
+  baseUrl = helper.getBaseUrl()
 
-  url: "#{helper.getBaseUrl()}/exists/#{list_ids}/#{values}"
+  url: "#{baseUrl}/exists/#{listNames}/#{values}"
   method: 'GET'
   headers: helper.getRequestHeaders(vars.activeprospect.api_key, false)
 
 request.variables = ->
   [
-    { name: 'list_ids',  description: 'SuppressionList List Id (comma separated)', required: true, type: 'string' }
-    { name: 'values', description: 'Item(s) to be looked up (phone/email/etc.)',   required: true, type: 'string' }
+    { name: 'list_names',  description: 'SuppressionList List URL Names (comma separated)', required: true, type: 'string' }
+    { name: 'values', description: 'Phone, email or other values to be looked up (comma separated)',   required: true, type: 'string' }
   ]
 
 
 response = (vars, req, res) ->
-  event = helper.parseResponse(res, true)
+  event = helper.parseResponse(res)
 
-  if event.outcome == 'success' and event.exists_in_lists?
+  if event.exists_in_lists?
     event.found_in = event.exists_in_lists
     delete event.exists_in_lists
 
@@ -28,10 +29,10 @@ response = (vars, req, res) ->
 
 response.variables = ->
   [
-    { name: 'query_item.outcome', type: 'string', description: 'Was SuppressionList response data appended?' },
-    { name: 'query_item.reason', type: 'string', description: 'Error reason' },
-    { name: 'query_item.found', type: 'boolean', description: 'is the lookup item found on any of the suppression lists?'},
-    { name: 'query_item.found_in', type: 'array', description: 'list of suppression lists the item was found within'}
+    { name: 'query_item.outcome', type: 'string', description: 'Was SuppressionList response data appended?' }
+    { name: 'query_item.reason', type: 'string', description: 'Error reason' }
+    { name: 'query_item.found', type: 'boolean', description: 'Is the lookup item found on any of the suppression lists?' }
+    { name: 'query_item.found_in', type: 'array', description: 'List of suppression lists the item was found within' }
   ]
 
 


### PR DESCRIPTION
This PR primarily changes the request variable from `list_id` to `list_name`. The `list_name` variable can be populated with the "URL Name" or the human readable list name. The change is backward compatible in that existing mappings using `list_id` or `list_ids` will continue working.

Adding items to lists now uses the more sensible `"values": ["foo","bar"]` instead of a pipe delimited string (`"values": "foo|bar"`). This is not backward compatible with currently deployed SuppressionList (depends on https://github.com/activeprospect/suppressionlist/pull/73), so SL will need to be updated first.

Other changes include cleaning up response parsing and tests. The special handling for https://github.com/activeprospect/suppressionlist/issues/18 has also been removed since that issue is resolved.

Should resolve #38, #26, #21.