### PR TITLE
fix common validate() to account for 'list_id' vs 'list_ids' differenc

### DIFF
--- a/spec/add_item_spec.coffee
+++ b/spec/add_item_spec.coffee
@@ -105,4 +105,4 @@ describe 'Add List Item', ->
 
   describe 'Validate', ->
     it 'should function properly', ->
-      assert.equal integration.validate(list_ids: 'foo'), 'values must not be blank'
+      assert.equal integration.validate(list_id: 'foo'), 'values must not be blank'

--- a/spec/delete_item_spec.coffee
+++ b/spec/delete_item_spec.coffee
@@ -106,4 +106,4 @@ describe 'Delete List Item', ->
 
   describe 'Validate', ->
     it 'should function properly', ->
-      assert.equal integration.validate(list_ids: 'foo'), 'values must not be blank'
+      assert.equal integration.validate(list_id: 'foo'), 'values must not be blank'

--- a/src/helper.coffee
+++ b/src/helper.coffee
@@ -19,7 +19,7 @@ getRequestHeaders = (api_key, setContentType = true) ->
 
 
 validate = (vars) ->
-  return 'list_ids must not be blank' unless vars.list_ids?
+  return 'list_ids must not be blank' unless vars.list_ids? or vars.list_id?
   return 'values must not be blank' unless vars.values
 
 


### PR DESCRIPTION
What do you think of this fix, instead of rolling back, @alexkwolfe? 