### PR TITLE
Including added_at response variable for found queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "csvrow": "^0.1.0",
+    "leadconduit-types": "^3.1.3",
     "lodash": "^3.10.1"
   },
   "devDependencies": {

--- a/spec/query_item_spec.coffee
+++ b/spec/query_item_spec.coffee
@@ -1,5 +1,6 @@
 assert = require('chai').assert
 integration = require('../src/query_item')
+time = require('leadconduit-types').time
 
 describe 'Query List Item', ->
 
@@ -29,7 +30,19 @@ describe 'Query List Item', ->
                 "specified_lists": ["list_1", "list_2", "list_3"],
                 "key": "taylor@activeprospect.com",
                 "found": true,
-                "exists_in_lists": ["list_2", "list_3"]
+                "exists_in_lists": ["list_2", "list_3"],
+                "entries": [
+                  {
+                    "list_id" : "558dbd69021823dc0b000001",
+                    "list_url_name" : "list_2",
+                    "added_at" : "2015-08-27T16:18:16Z"
+                  },
+                  {
+                    "list_id" : "558dbd69021823dc0b000002",
+                    "list_url_name" : "list_3",
+                    "added_at" : "2015-08-28T16:18:16Z"
+                  }
+                ]
               }
               """
       expected =
@@ -39,9 +52,11 @@ describe 'Query List Item', ->
           specified_lists: ["list_1", "list_2", "list_3"]
           key: 'taylor@activeprospect.com'
           found: true
+          added_at: time.parse('2015-08-28T16:18:16Z')
           found_in: ["list_2", "list_3"]
       response = integration.response(vars, req, res)
       assert.deepEqual response, expected
+      assert.instanceOf response.query_item.added_at, Date
 
     it 'should return error outcome on non-200 response status', ->
       vars = {}

--- a/src/helper.coffee
+++ b/src/helper.coffee
@@ -62,14 +62,6 @@ parseResponse = (res) ->
 getBaseUrl = ->
   switch process.env.NODE_ENV
     when 'production', 'test' then 'https://app.suppressionlist.com'
-    when 'staging' then 'https://staging.suppressionlist.com'
-    when 'development' then 'http://suppressionlist.dev'
-
-
-
-getBaseUrl = ->
-  switch process.env.NODE_ENV
-    when 'production', 'test' then 'https://app.suppressionlist.com'
     when 'staging' then 'http://staging.suppressionlist.com'
     when 'development' then 'http://suppressionlist.dev'
 

--- a/src/query_item.coffee
+++ b/src/query_item.coffee
@@ -1,5 +1,6 @@
 _ = require('lodash')
 helper = require('./helper')
+time = require('leadconduit-types').time
 
 request = (vars) ->
   listNames = helper.getListUrlNames(vars)
@@ -24,6 +25,9 @@ response = (vars, req, res) ->
     event.found_in = event.exists_in_lists
     delete event.exists_in_lists
 
+    event.added_at = time.parse _.last(_.sortBy(event.entries, 'added_at')).added_at
+    delete event.entries
+
   query_item: event
 
 
@@ -33,6 +37,7 @@ response.variables = ->
     { name: 'query_item.reason', type: 'string', description: 'Error reason' }
     { name: 'query_item.found', type: 'boolean', description: 'Is the lookup item found on any of the suppression lists?' }
     { name: 'query_item.found_in', type: 'array', description: 'List of suppression lists the item was found within' }
+    { name: 'query_item.added_at', type: 'time', description: 'Most recent timestamp the found query item was added at' }
   ]
 
 


### PR DESCRIPTION
This change adds an `added_at` response variable for found queries. It returns as a `Time` type, so that time comparisons can be made from following steps.

Fixes #46 

@cgrayson can you take a look when you get a chance?