### PR TITLE
Use query_item.found when creating a filter

### DIFF
--- a/src/ui/public/app/index.js
+++ b/src/ui/public/app/index.js
@@ -107,9 +107,8 @@ function init(config) {
             rule_set: {
               op: 'and',
               rules: [{
-                op: 'is equal to',
-                lhv: 'suppressionlist.query_item.outcome',
-                rhv: 'failure'
+                op: 'is true',
+                lhv: 'suppressionlist.query_item.found'
               }]
             }
           });


### PR DESCRIPTION
Selecting the 'Query list' option in rich SL integration adds a filter that looks at the value associated with 'SuppressionList Query List Outcome' instead of 'SuppressionList Query Item Found'. The outcome will be 'Success' if the item is found, or it isn't found. So ultimately, the SL filter (added automatically by the rich UI) doesn't reject a lead when a value is found on the list. This filter needs to look for whether or not the item is found and filter based on that. (edited)

https://next.leadconduit.com/events/596e2df6104e3d5a154c429e?event_id=596e2df6104e3d5a154c429f

https://next.leadconduit.com/events/596e2df8a56bfd5a1b79178f?event_id=596e2df8a56bfd5a1b791790

---
See https://activeprospect.slack.com/archives/C034BK84K/p1500393266883400.