### PR TITLE
fix cpl token masking for is_unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org)
 
+## [2.3.13] - 2025-04-30
+### Fixed
+- now properly masks CPL-Token header in all cases for `is_unique`
+
 ## [2.3.12] - 2025-04-17
 ### Added
 - now sends CPL-Token header when token is present ([sc-88135](https://app.shortcut.com/active-prospect/story/88135/send-cpl-data-to-suppressionlist))

--- a/lib/is-unique.js
+++ b/lib/is-unique.js
@@ -36,13 +36,9 @@ const query = wrap(queryItem);
 const add = wrap(addItem);
 
 const handle = (vars, callback) => {
-  const queryVars = {
-    list_name: [vars.list_name],
-    value: vars.value,
-    activeprospect: vars.activeprospect
-  };
-
-  query(queryVars, (err, queryEvent) => {
+  // check for existence of CPL token to determine if we should mask it
+  const shouldMaskCplToken = !!vars.cplToken;
+  query(vars, (err, queryEvent) => {
     if (err) return callback(err);
     // Duplicating data here until affected flows are corrected
     const event = _.merge({ is_unique: {} }, queryEvent);
@@ -60,6 +56,8 @@ const handle = (vars, callback) => {
     const found = _.get(queryEvent, 'query_item.found');
 
     if (!found) {
+      // delete CPL token on vars so that it isn't masked for the second request
+      if (!shouldMaskCplToken) delete vars.cplToken;
       add(vars, (err, addEvent) => {
         if (err) return callback(err);
         // Duplicating data here until affected flows are corrected


### PR DESCRIPTION
## Description of the change

This is a somewhat awkward fix to account for `is_unique` being able to make either one or two requests.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/88135/send-cpl-data-to-suppressionlist

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [ ]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [ ]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
